### PR TITLE
New admin UI with settings and status on the import

### DIFF
--- a/os2web_emply_job.admin.inc
+++ b/os2web_emply_job.admin.inc
@@ -93,6 +93,9 @@ function os2web_emply_job_settings_submit($form, &$form_state) {
   drupal_set_message(t('Settings saved successfully!'));
 }
 
+/**
+ * Page callback rendering the feeds log view.
+ */
 function os2web_emply_job_log_view() {
   // Setting page title
   drupal_set_title(t('Log for the Emply job importer'));

--- a/os2web_emply_job.admin.inc
+++ b/os2web_emply_job.admin.inc
@@ -8,12 +8,100 @@
  * System settings form for configuration of the Emply job import.
  */
 function os2web_emply_job_settings_form($form, $form_state) {
-  $form['os2web_emply_job_position_category_guid'] = array(
+  module_load_include('inc', 'feeds', 'feeds.pages');
+  $importer_id = OS2WEB_EMPLY_JOB_FEEDS_MACHINE_NAME;
+
+  // Settings form
+  $form['settings'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Settings'),
+  );
+  $form['settings']['position_category_guid'] = array(
     '#type' => 'textfield',
     '#title' => t('Position category GUID'),
     '#description' => t('The GUID attribute from the facts node containing the position category.'),
     '#default_value' => variable_get('os2web_emply_job_position_category_guid', ''),
     '#size' => 60,
   );
-  return system_settings_form($form);
+  $form['settings']['feeds_source_url'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Feeds source URL'),
+    '#description' => t('Enter the feed source URL for the Emply Job importer.'),
+    '#default_value' => os2web_emply_job_feeds_url_get(),
+    '#size' => 60,
+  );
+  $form['settings']['save'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save settings'),
+    '#submit' => array('os2web_emply_job_settings_submit'),
+  );
+
+  // Showing the current import status
+  if (feeds_access('import', $importer_id) || feeds_access('clear', $importer_id) || feeds_access('unlock', $importer_id)) {
+    $source = feeds_source($importer_id);
+    $form['status'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Status'),
+      '#value' => feeds_source_status($source),
+    );
+    $form['actions'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Actions'),
+    );
+    // Various hidden fields used by the action buttons.
+    $form['#redirect'] = os2web_emply_job_config_path() . '/os2web_emply_jobs';
+    $form['#importer_id'] = $importer_id;
+  }
+
+  // Actions: import button
+  if (feeds_access('import', $importer_id)) {
+    $import = feeds_import_form(array(), $form_state, $importer_id);
+    $form['actions']['import_submit'] = $import['submit'];
+    $form['actions']['import_submit']['#submit'] = array('feeds_import_form_submit');
+    unset($form['actions']['submit']);
+  }
+
+  // Actions: delete button
+  if (feeds_access('clear', $importer_id)) {
+    $delete = feeds_delete_tab_form(array(), $form_state, $importer_id);
+    $form['actions']['delete_submit'] = $delete['actions']['submit'];
+    $form['actions']['delete_submit']['#submit'] = array('feeds_delete_tab_form_submit');
+    $form['actions']['delete_submit']['#value'] = t('Delete items');
+  }
+
+  // Actions: unlock button
+  if (feeds_access('unlock', $importer_id)) {
+    $unlock = feeds_unlock_tab_form(array(), $form_state, $importer_id);
+    $form['actions']['unlock_submit'] = $unlock['actions']['submit'];
+    $form['actions']['unlock_submit']['#submit'] = array('feeds_unlock_tab_form_submit');
+  }
+
+  // Some of the feeds forms are overwriting the page tile, so we set it agian.
+  drupal_set_title(t('OS2Web Emply Job'));
+
+  return $form;
+}
+
+/**
+ * Submit callback; save Emply job settings.
+ *
+ * @ingroup forms
+ */
+function os2web_emply_job_settings_submit($form, &$form_state) {
+  variable_set('os2web_emply_job_position_category_guid', $form_state['values']['position_category_guid']);
+  os2web_emply_job_feeds_url_set($form_state['values']['feeds_source_url']);
+  drupal_set_message(t('Settings saved successfully!'));
+}
+
+function os2web_emply_job_log_view() {
+  // Setting page title
+  drupal_set_title(t('Log for the Emply job importer'));
+
+  // Embedding view
+  $data = views_embed_view('feeds_log', 'page_1', OS2WEB_EMPLY_JOB_FEEDS_MACHINE_NAME);
+
+  // Fixing wrong form action in exposed filter form
+  $data = str_replace('import/os2web_emply_job/log', $_GET['q'], $data);
+
+  return $data;
 }

--- a/os2web_emply_job.admin.inc
+++ b/os2web_emply_job.admin.inc
@@ -29,6 +29,7 @@ function os2web_emply_job_settings_form($form, $form_state) {
     '#description' => t('Enter the feed source URL for the Emply Job importer.'),
     '#default_value' => os2web_emply_job_feeds_url_get(),
     '#size' => 60,
+	'#maxlength' => 255,
   );
   $form['settings']['save'] = array(
     '#type' => 'submit',

--- a/os2web_emply_job.module
+++ b/os2web_emply_job.module
@@ -6,6 +6,8 @@
 
 include_once 'os2web_emply_job.features.inc';
 
+define('OS2WEB_EMPLY_JOB_FEEDS_MACHINE_NAME', 'os2web_emply_job');
+
 /**
  * Implements hook_ctools_plugin_directory().
  */
@@ -19,16 +21,48 @@ function os2web_emply_job_ctools_plugin_directory($owner, $plugin_type) {
  * Implements hook_menu().
  */
 function  os2web_emply_job_menu() {
+  $config_path = os2web_emply_job_config_path();
   $items = array();
-  $items['admin/config/os2web/os2web_emply_jobs'] = array(
+  $items[$config_path . '/os2web_emply_jobs'] = array(
     'title' => 'OS2Web Emply Job',
     'description' => 'Settings for the OS2Web Emply Job importer.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('os2web_emply_job_settings_form'),
-    'access arguments' => array('administer os2web'),
+    'access arguments' => array('administer os2web emply job settings'),
     'file' => 'os2web_emply_job.admin.inc',
   );
+  $items[$config_path . '/os2web_emply_jobs/settings'] = array(
+    'title' => 'Settings',
+    'description' => 'Settings for the OS2Web Emply Job importer.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('os2web_emply_job_settings_form'),
+    'access arguments' => array('administer os2web emply job settings'),
+    'file' => 'os2web_emply_job.admin.inc',
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+    'weight' => 1,
+  );
+  $items[$config_path . '/os2web_emply_jobs/log'] = array(
+    'title' => 'Import log',
+    'description' => 'Log for the Emply job importer.',
+    'page callback' => 'os2web_emply_job_log_view',
+    'access callback' => 'os2web_emply_job_log_access',
+    'file' => 'os2web_emply_job.admin.inc',
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 2,
+  );
   return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function os2web_emply_job_permission() {
+  return array(
+    'administer os2web emply job settings' => array(
+      'title' => t('Administer OS2Web Emply Job settings'),
+      'description' => t('Administer settings for the OS2Web Emply Job module.'),
+    ),
+  );
 }
 
 /**
@@ -40,6 +74,18 @@ function os2web_emply_job_theme() {
       'variables' => array('facts' => NULL),
     ),
   );
+}
+
+/**
+ * Menu access callback.
+ *
+ * Checking access to the log tab on the settings page.
+ */
+function os2web_emply_job_log_access() {
+  if (user_access('administer feeds') && user_access("administer os2web emply job settings")) {
+    return TRUE;
+  }
+  return FALSE;
 }
 
 /**
@@ -58,4 +104,52 @@ function theme_os2web_emply_job_facts($variables) {
   }
 
   return $html;
+}
+
+/**
+ * Find and return the existing feeds URL.
+ *
+ * @return string
+ *   The feeds URL.
+ */
+function os2web_emply_job_feeds_url_get() {
+  $feeds_source = feeds_source(OS2WEB_EMPLY_JOB_FEEDS_MACHINE_NAME);
+  $feeds_config = $feeds_source->getConfigFor($feeds_source->importer->fetcher);
+  if (isset($feeds_config['source']) && !empty($feeds_config['source'])) {
+    return $feeds_config['source'];
+  }
+  else {
+    return '';
+  }
+}
+
+/**
+ * Set and save the feeds URL.
+ *
+ * @param string $url
+ *   The feeds URL.
+ *
+ * @return void
+ */
+function os2web_emply_job_feeds_url_set($url) {
+  $feeds_source = feeds_source(OS2WEB_EMPLY_JOB_FEEDS_MACHINE_NAME);
+  $feeds_config = $feeds_source->getConfigFor($feeds_source->importer->fetcher);
+  $feeds_config['source'] = $url;
+  $feeds_source->setConfigFor($feeds_source->importer->fetcher, $feeds_config);
+  $feeds_source->save();
+}
+
+/**
+ * Find the config path.
+ *
+ * @return string
+ *   The config path.
+ */
+function os2web_emply_job_config_path() {
+  if (module_exists('os2web_settings_page')) {
+    return 'admin/os2web_settings/services';
+  }
+  else {
+    return 'admin/config/services';
+  }
 }


### PR DESCRIPTION
The normal /import UI is not in the administration theme and not working that well. I have implemented a new admin page (admin/config/services/os2web_emply_jobs) where it is possible to configure the feed import (feed URL and position category GUID), trigger the import, delete imported jobs, unlock the importer and view the import log. 
